### PR TITLE
refactor: update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Reason for this assumption is twofold:
 2. In cases where the the network is NOT offline but really slow (think 2G in a third world country) and the request doesn't reach the server anyway,
    our queue retries until the server responds with success.
 
-Tested with Apollo version 3.0.0-beta.23
+Tested with Apollo version 3.7.14
 
 ### Setup
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 declare module 'apollo-link-offline' {
+  import type { ApolloLink, NextLink, Operation, gql } from '@apollo/client';
   import type { AsyncStorageStatic } from '@react-native-community/async-storage';
-  import type gql from 'graphql-tag';
-  import type { ApolloLink, Operation, NextLink } from '@apollo/client/link/core';
 
   type Options = Partial<{
     storage: AsyncStorageStatic;
@@ -17,9 +16,9 @@ declare module 'apollo-link-offline' {
 
     request(operation: Operation, forward: NextLink): any;
 
-    async migrate(): Promise<void>;
+    migrate(): Promise<void>;
 
-    async getQueue(): Promise<Map<string, Record<string, any>>>;
+    getQueue(): Promise<Map<string, Record<string, any>>>;
 
     saveQueue(attemptId: string, item: Record<string, any>): void;
 
@@ -29,8 +28,8 @@ declare module 'apollo-link-offline' {
 
     remove(itemId: string): void;
 
-    async sync(): Promise<void>;
+    sync(): Promise<void>;
 
-    async setup(client: any): Promise<void>;
+    setup(client: any): Promise<void>;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "apollo-link-offline",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "An Apollo Link to queue mutations when offline or network errors exist.",
   "repository": "github:carvajalconsultants/apollo-link-offline",
   "main": "./src/index.js",
   "types": "index.d.ts",
   "author": "Miguel Carvajal <omar@carvajalonline.com>",
   "license": "MIT",
-  "private": false,
-  "dependencies": {
-    "apollo-link": "^1.2.3",
-    "uuid": "^3.3.2"
+  "peerDependencies": {
+    "@apollo/client": "^3.7.14",
+    "lodash": "^4.17.15",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/OfflineLink.js
+++ b/src/OfflineLink.js
@@ -1,7 +1,6 @@
-import { ApolloLink, Observable } from "apollo-link";
+import { ApolloLink, Observable, gql } from "@apollo/client";
 import debounce from "lodash/debounce";
-import uuidv4 from "uuid/v4";
-import gql from "graphql-tag";
+import { v4 as uuidv4 } from 'uuid';
 
 const syncStatusQuery = gql`
   query syncStatus {
@@ -41,8 +40,8 @@ export default class OfflineLink extends ApolloLink {
 
   request(operation, forward) {
     const me = this,
-          context = operation.getContext(),
-          { query, variables } = operation || {};
+      context = operation.getContext(),
+      { query, variables } = operation || {};
 
     if (!context.optimisticResponse) {
       // If the mutation does not have an optimistic response then we don't defer it
@@ -50,7 +49,7 @@ export default class OfflineLink extends ApolloLink {
     }
 
     return new Observable(observer => {
-      const attemptId = this.add({mutation: query, variables, optimisticResponse: context.optimisticResponse});
+      const attemptId = this.add({ mutation: query, variables, optimisticResponse: context.optimisticResponse });
 
       const subscription = forward(operation).subscribe({
         next: result => {
@@ -146,10 +145,10 @@ export default class OfflineLink extends ApolloLink {
           resolve(map);
         }
       })
-      .catch(err => {
-        // Most likely happens the first time a mutation attempt is being persisted.
-        resolve(new Map());
-      });
+        .catch(err => {
+          // Most likely happens the first time a mutation attempt is being persisted.
+          resolve(new Map());
+        });
     });
   }
 
@@ -171,11 +170,13 @@ export default class OfflineLink extends ApolloLink {
    * Updates a SyncStatus object in the Apollo Cache so that the queue status can be obtained and dynamically updated.
    */
   updateStatus(inflight) {
-    this.client.writeQuery({query: syncStatusQuery, data: {
-      __typename: "SyncStatus",
-      mutations: this.queue.size,
-      inflight
-    }});
+    this.client.writeQuery({
+      query: syncStatusQuery, data: {
+        __typename: "SyncStatus",
+        mutations: this.queue.size,
+        inflight
+      }
+    });
   }
 
   /**
@@ -226,7 +227,7 @@ export default class OfflineLink extends ApolloLink {
 
       for (const [attemptId, attempt] of attempts) {
         const success = await this.client
-          .mutate({...attempt, optimisticResponse: undefined})
+          .mutate({ ...attempt, optimisticResponse: undefined })
           .then(() => {
             // Mutation was successfully executed so we remove it from the queue
 
@@ -246,7 +247,7 @@ export default class OfflineLink extends ApolloLink {
               return false;
             }
           })
-        ;
+          ;
 
         if (!success) {
           // The last mutation failed so we don't attempt any more
@@ -270,7 +271,7 @@ export default class OfflineLink extends ApolloLink {
               this.remove(attemptId)
             }
           })
-        ;
+          ;
       }));
     }
 


### PR DESCRIPTION
As stated in #12 i created a PR for updating the package to use the latest apollo/client version.
This PR would close #12 

## CHANGELOG:
- [x] mark package `dependencies` as `peerDependencies`
- [x] update tested apollo version in `README`
- [x] update `@apollo/client` version and usage
- [x] update `uuid ` version and usage
- [X] minor format changes based on prettier defaults

PS: thx for the lib, quite a solid apollo-link, maybe one day it goes into `@apollo/client` itself ;)